### PR TITLE
jenkinsx-meetup-quickstart to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.89
 - name: jenkinsx-meetup-quickstart
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.2


### PR DESCRIPTION
Promote jenkinsx-meetup-quickstart to version 0.0.2